### PR TITLE
fix(telemetry): dedupe retries by uuid and bound the send queue (v1.55.3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@withone/cli",
-  "version": "1.55.2",
+  "version": "1.55.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withone/cli",
-      "version": "1.55.2",
+      "version": "1.55.3",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
         "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withone/cli",
-  "version": "1.55.2",
+  "version": "1.55.3",
   "description": "CLI for managing One",
   "type": "module",
   "files": [

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -184,11 +184,14 @@ program.hook('postAction', async () => {
   // immediately but the process hangs for ~10s before exiting.
   await closeBackendIfCached();
 
-  // Flush any usage rollup that came due during the command, then stop any
-  // in-flight telemetry send so it can't hold the process open, persisting
-  // anything undelivered for retry next run. See lib/analytics.ts.
+  // Flush any usage rollup that came due during the command and start sending
+  // it, then let in-flight telemetry sends finish for a few hundred ms at most
+  // before aborting them so they can't hold the process open; anything
+  // undelivered is persisted for a (bounded, deduped) retry next run. See
+  // lib/analytics.ts.
   analytics.flushUsageRollups();
-  analytics.flush();
+  analytics.drainQueue();
+  await analytics.flush();
 
   if (!updateCheckPromise) return;
   const info = await updateCheckPromise;

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -5,8 +5,23 @@ import os from 'node:os';
 import path from 'node:path';
 import type { Command } from 'commander';
 
-import { recordCommand, flushUsageRollups } from './analytics.js';
-import { appendUsageLog, readUsageLog, readAnalyticsQueue, claimUsageLog } from './config.js';
+import {
+  recordCommand,
+  flushUsageRollups,
+  capture,
+  drainQueue,
+  flush,
+  uuidFromInsertId,
+  SEND_MAX_ATTEMPTS,
+  QUEUE_MAX_AGE_MS,
+} from './analytics.js';
+import {
+  appendUsageLog,
+  readUsageLog,
+  readAnalyticsQueue,
+  writeAnalyticsQueue,
+  claimUsageLog,
+} from './config.js';
 import { setHomeTo, snapshotHomeEnv, restoreHomeEnv } from '../test-support/home.js';
 
 // These tests exercise the REAL rollup code against REAL files: HOME is
@@ -268,5 +283,219 @@ describe('CLI usage rollups', () => {
     const second = claimUsageLog();
     assert.equal(first?.length, 3, 'first claimant gets the whole batch');
     assert.equal(second, null, 'a concurrent second claimant gets nothing → cannot double-emit');
+  });
+
+  // ── Fix 4: rollups are billed at the anonymous rate ─────────────────────────
+  it('rollups opt out of person processing and carry no $set', () => {
+    const old = Date.now() - WINDOW_MS - 1000;
+    appendUsageLog(logEntry({ did: 'whale', ts: old }));
+    flushUsageRollups();
+    const [r] = emittedRollups();
+    const props = r.properties as Record<string, unknown>;
+    assert.equal(props.$process_person_profile, false, 'rollup is an anonymous-rate event');
+    assert.equal(props.$set, undefined, 'no person properties ride on a rollup');
+  });
+});
+
+// ── Delivery: PostHog dedupes on `uuid`, and retries must be bounded ─────────
+//
+// Background: a CLI process aborts in-flight sends at exit. The request body
+// has usually already left, so PostHog ingests the event, but the CLI never
+// learns that and re-sends the whole backlog on the next run — and PostHog
+// does NOT dedupe on `$insert_id`, only on `uuid`. One user produced 233 copies
+// of each rollup this way.
+
+interface QueuedLine {
+  event: string;
+  uuid?: string;
+  timestamp: string;
+  properties: Record<string, unknown> & { $insert_id?: string };
+  attempts?: number;
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+function queuedLines(): QueuedLine[] {
+  return readAnalyticsQueue().map((l) => JSON.parse(l) as QueuedLine);
+}
+
+/** A fetch stub that records request bodies and resolves per `mode`. */
+function stubFetch(mode: 'ok' | 'hang' | 'fail' | 'slow-ok') {
+  const bodies: Array<Record<string, unknown>> = [];
+  const original = globalThis.fetch;
+  globalThis.fetch = ((_url: unknown, init?: RequestInit) => {
+    bodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+    const signal = init?.signal;
+    return new Promise<Response>((resolve, reject) => {
+      const done = () => resolve(new Response('', { status: 200 }));
+      if (mode === 'ok') done();
+      else if (mode === 'slow-ok') setTimeout(done, 40);
+      else if (mode === 'fail') reject(new Error('network down'));
+      // 'hang': resolve only via abort
+      signal?.addEventListener('abort', () => reject(new Error('aborted')));
+    });
+  }) as typeof fetch;
+  return { bodies, restore: () => { globalThis.fetch = original; } };
+}
+
+describe('CLI analytics delivery', () => {
+  let tmpDir: string;
+  let originalCwd: string;
+  const orig: Record<string, string | undefined> = {};
+  let restoreFetch: (() => void) | undefined;
+
+  beforeEach(() => {
+    for (const k of ['HOME', 'CI', 'ONE_NO_TELEMETRY', 'ONE_DISABLE_TELEMETRY', 'DO_NOT_TRACK', 'ONE_SECRET']) {
+      orig[k] = process.env[k];
+    }
+    originalCwd = process.cwd();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'one-cli-delivery-test-'));
+    const home = path.join(tmpDir, 'home');
+    fs.mkdirSync(home, { recursive: true });
+    setHomeTo(home);
+    process.chdir(home);
+    delete process.env.CI;
+    delete process.env.ONE_NO_TELEMETRY;
+    delete process.env.ONE_DISABLE_TELEMETRY;
+    delete process.env.DO_NOT_TRACK;
+    process.env.ONE_SECRET = 'sk_live_test_key';
+  });
+
+  afterEach(async () => {
+    restoreFetch?.();
+    restoreFetch = undefined;
+    await flush(); // settle anything a test left in flight
+    process.chdir(originalCwd);
+    for (const [k, v] of Object.entries(orig)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
+  });
+
+  it('uuidFromInsertId is deterministic and yields a valid v5-shaped UUID', () => {
+    const a = uuidFromInsertId('abc123');
+    assert.match(a, UUID_RE);
+    assert.equal(a, uuidFromInsertId('abc123'), 'same input → same uuid');
+    assert.notEqual(a, uuidFromInsertId('abc124'), 'different input → different uuid');
+    const already = '123e4567-e89b-42d3-a456-426614174000';
+    assert.equal(uuidFromInsertId(already), already, 'an id that already is a UUID is kept as is');
+  });
+
+  it('every queued event carries a uuid derived from its $insert_id', () => {
+    capture('Something Happened', { $insert_id: 'content-hash-1' });
+    capture('Other Thing');
+    const [a, b] = queuedLines();
+    assert.equal(a.uuid, uuidFromInsertId('content-hash-1'));
+    assert.match(String(b.uuid), /^[0-9a-f-]{36}$/);
+    assert.equal(b.uuid, uuidFromInsertId(String(b.properties.$insert_id)));
+  });
+
+  it('sends the uuid to PostHog so a re-sent copy dedupes on ingest', () => {
+    const stub = stubFetch('ok');
+    restoreFetch = stub.restore;
+    capture('Something Happened', { $insert_id: 'content-hash-1' });
+    drainQueue();
+    assert.equal(stub.bodies.length, 1);
+    assert.equal(stub.bodies[0].uuid, uuidFromInsertId('content-hash-1'));
+    assert.equal((stub.bodies[0].properties as Record<string, unknown>).$insert_id, 'content-hash-1');
+  });
+
+  it('backfills a uuid for queue lines written by an older CLI', () => {
+    const stub = stubFetch('ok');
+    restoreFetch = stub.restore;
+    writeAnalyticsQueue([
+      JSON.stringify({
+        event: 'CLI Usage Rollup',
+        distinct_id: 'u',
+        timestamp: new Date().toISOString(),
+        properties: { $insert_id: 'legacy-hash' },
+      }),
+    ]);
+    drainQueue();
+    assert.equal(stub.bodies[0].uuid, uuidFromInsertId('legacy-hash'));
+  });
+
+  it('a delivered event leaves the queue after flush', async () => {
+    const stub = stubFetch('ok');
+    restoreFetch = stub.restore;
+    capture('Something Happened');
+    drainQueue();
+    await flush();
+    assert.equal(queuedLines().length, 0);
+  });
+
+  it('flush waits briefly for an in-flight send instead of aborting it', async () => {
+    const stub = stubFetch('slow-ok'); // completes in ~40ms, well inside the grace period
+    restoreFetch = stub.restore;
+    capture('Something Happened');
+    drainQueue();
+    await flush();
+    assert.equal(queuedLines().length, 0, 'delivered within the grace period → not retried');
+  });
+
+  it('counts an attempt each time an event is dispatched and drops it after the cap', async () => {
+    const stub = stubFetch('hang'); // every attempt gets aborted at exit
+    restoreFetch = stub.restore;
+    capture('Something Happened');
+    for (let run = 1; run <= SEND_MAX_ATTEMPTS; run++) {
+      drainQueue();
+      await flush();
+      if (run < SEND_MAX_ATTEMPTS) {
+        assert.equal(queuedLines().length, 1, `still queued after run ${run}`);
+        assert.equal(queuedLines()[0].attempts, run, `attempts persisted after run ${run}`);
+      }
+    }
+    assert.equal(queuedLines().length, 0, `dropped after ${SEND_MAX_ATTEMPTS} dispatches`);
+    assert.equal(stub.bodies.length, SEND_MAX_ATTEMPTS, 'dispatched exactly the cap, never more');
+    drainQueue();
+    await flush();
+    assert.equal(stub.bodies.length, SEND_MAX_ATTEMPTS, 'nothing left to re-send');
+  });
+
+  it('drops events older than the age cap without sending them', () => {
+    const stub = stubFetch('ok');
+    restoreFetch = stub.restore;
+    writeAnalyticsQueue([
+      JSON.stringify({
+        event: 'CLI Usage Rollup',
+        distinct_id: 'u',
+        timestamp: new Date(Date.now() - QUEUE_MAX_AGE_MS - 60_000).toISOString(),
+        properties: { $insert_id: 'stale' },
+      }),
+      JSON.stringify({
+        event: 'CLI Usage Rollup',
+        distinct_id: 'u',
+        timestamp: new Date().toISOString(),
+        properties: { $insert_id: 'fresh' },
+      }),
+    ]);
+    drainQueue();
+    assert.equal(stub.bodies.length, 1, 'only the fresh event is sent');
+    assert.equal((stub.bodies[0].properties as Record<string, unknown>).$insert_id, 'fresh');
+    assert.deepEqual(
+      queuedLines().map((l) => l.properties.$insert_id),
+      ['fresh'],
+      'the stale event is gone from the queue',
+    );
+  });
+
+  it('does not dispatch the same event twice within one run', () => {
+    const stub = stubFetch('hang');
+    restoreFetch = stub.restore;
+    capture('Something Happened');
+    drainQueue();
+    drainQueue(); // e.g. a second drain at postAction
+    assert.equal(stub.bodies.length, 1);
+  });
+
+  it('a failed send is retried on the next run (queue kept, attempt counted)', async () => {
+    const stub = stubFetch('fail');
+    restoreFetch = stub.restore;
+    capture('Something Happened');
+    drainQueue();
+    await flush();
+    assert.equal(queuedLines().length, 1);
+    assert.equal(queuedLines()[0].attempts, 1);
   });
 });

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -46,11 +46,17 @@ import { cliVersion } from './version.js';
  * DELIVERY — a CLI process is short-lived and a network round-trip is ~1s, so
  * we never make the user wait: each event is written to a tiny on-disk queue
  * instantly (sync), the queue is sent in the background overlapping the
- * command, in-flight requests are aborted at exit (so they can't hold the
- * process open), and anything not confirmed delivered is retried on the next
- * run. A stable `$insert_id` lets PostHog dedupe the occasional re-send. Net:
- * zero added latency, no lost events. (This is the standard CLI-telemetry
- * pattern used by tools like Next.js.)
+ * command, and anything not confirmed delivered is retried on the next run.
+ * At exit we give in-flight requests a short grace period (EXIT_GRACE_MS),
+ * then abort whatever is left so telemetry can never hold the process open.
+ *
+ * Retries are idempotent and bounded. An aborted request has usually already
+ * left the machine, so PostHog ingests it while the CLI still thinks it is
+ * undelivered; PostHog dedupes on the event `uuid` (NOT on `$insert_id`), so
+ * every event carries a `uuid` derived from its `$insert_id` and a re-sent copy
+ * collapses on ingest. Each event also counts its dispatches and is dropped
+ * after SEND_MAX_ATTEMPTS or QUEUE_MAX_AGE_MS, so a stuck backlog can never
+ * replay forever (one user's queue once re-sent every rollup ~230 times).
  *
  * PRIVACY — on by default (opt-out), per CLI norms. We never send positional
  * args or flag values (they can contain emails, queries, payloads, secrets) —
@@ -79,12 +85,42 @@ interface QueuedEvent {
   distinct_id: string;
   properties: Record<string, unknown>;
   timestamp: string;
+  /** PostHog's dedupe key; derived from `$insert_id` (see uuidFromInsertId). */
+  uuid?: string;
+  /** How many runs have dispatched this event; dropped at SEND_MAX_ATTEMPTS. */
+  attempts?: number;
 }
+
+/** An event is dropped once it has been dispatched this many times. */
+export const SEND_MAX_ATTEMPTS = 3;
+/** ...or once it is older than this (a stale backlog is not worth replaying). */
+export const QUEUE_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+/** How long flush() lets in-flight sends finish before aborting them at exit. */
+export const EXIT_GRACE_MS = 300;
 
 /** Abort controllers for in-flight sends, so flush() can cancel them at exit. */
 const inFlight = new Set<AbortController>();
+/** The in-flight send promises, so flush() can wait (briefly) for them. */
+const pending = new Set<Promise<void>>();
+/** `$insert_id`s dispatched this run (never send the same event twice per run). */
+const dispatched = new Set<string>();
 /** `$insert_id`s confirmed delivered this run (so flush() drops them from the queue). */
 const delivered = new Set<string>();
+
+const UUID_SHAPE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * The event `uuid` PostHog dedupes on, derived deterministically from the
+ * `$insert_id` so a re-sent copy of an event carries the same uuid and
+ * collapses on ingest. A v5-shaped UUID built from a SHA-1 of the id; an id
+ * that already is a UUID is used as is.
+ */
+export function uuidFromInsertId(insertId: string): string {
+  if (UUID_SHAPE.test(insertId)) return insertId.toLowerCase();
+  const h = createHash('sha1').update(`one-cli-event:${insertId}`).digest('hex');
+  const variant = ((parseInt(h[16], 16) & 0x3) | 0x8).toString(16);
+  return `${h.slice(0, 8)}-${h.slice(8, 12)}-5${h.slice(13, 16)}-${variant}${h.slice(17, 20)}-${h.slice(20, 32)}`;
+}
 
 function posthogHost(): string {
   return process.env.ONE_POSTHOG_HOST || DEFAULT_POSTHOG_HOST;
@@ -166,9 +202,10 @@ function personSet(): Record<string, unknown> | undefined {
 /** Fire one queued event to PostHog (best-effort); mark it delivered on success. */
 function send(item: QueuedEvent): void {
   const insertId = item.properties.$insert_id as string | undefined;
+  if (insertId) dispatched.add(insertId);
   const controller = new AbortController();
   inFlight.add(controller);
-  void (async () => {
+  const run = (async () => {
     try {
       const res = await fetch(`${posthogHost()}/i/v0/e/`, {
         method: 'POST',
@@ -177,6 +214,8 @@ function send(item: QueuedEvent): void {
           api_key: posthogKey(),
           event: item.event,
           distinct_id: item.distinct_id,
+          // PostHog's dedupe key — a re-sent copy is dropped on ingest.
+          uuid: item.uuid ?? (insertId ? uuidFromInsertId(insertId) : undefined),
           properties: item.properties,
           timestamp: item.timestamp,
         }),
@@ -186,12 +225,14 @@ function send(item: QueuedEvent): void {
       debugLog(`"${item.event}" -> HTTP ${res.status}${res.ok ? '' : ' (retry next run)'}`);
     } catch (err) {
       // Best-effort: a tracking failure must never affect the command; the
-      // event stays queued and is retried on the next run.
+      // event stays queued and is retried on the next run (bounded, see drainQueue).
       debugLog(`"${item.event}" not sent: ${err instanceof Error ? err.message : String(err)} (retry next run)`);
     } finally {
       inFlight.delete(controller);
     }
   })();
+  pending.add(run);
+  void run.finally(() => pending.delete(run));
 }
 
 /**
@@ -202,7 +243,7 @@ function send(item: QueuedEvent): void {
 export function capture(
   event: string,
   properties: Record<string, unknown> = {},
-  opts: { distinctId?: string; timestamp?: string } = {},
+  opts: { distinctId?: string; timestamp?: string; personProfile?: boolean } = {},
 ): void {
   if (isTelemetryDisabled()) {
     debugLog(`disabled — skipping "${event}"`);
@@ -211,11 +252,18 @@ export function capture(
   const did = opts.distinctId ?? distinctId();
   const props: Record<string, unknown> = { ...baseProperties(), ...properties };
   // One-off events get a random id; rollups pass a content-derived id (see
-  // emitRollup) so duplicate batches collapse to a single event in PostHog.
+  // emitRollup). The id is mirrored into the event `uuid`, which is what
+  // PostHog actually dedupes on, so a re-sent copy collapses to one event.
   if (props.$insert_id === undefined) props.$insert_id = randomUUID();
-  // Person props belong only to the *current* user; never tag a rollup for a
-  // previous login (distinct_id ≠ current) with the new user's email/name.
-  if (did === distinctId()) {
+  const insertId = props.$insert_id as string;
+  if (opts.personProfile === false) {
+    // Anonymous-rate event: no person profile is created or updated for it
+    // (rollups don't need one — the signup events already made the person),
+    // and person properties would be ignored, so none are attached.
+    props.$process_person_profile = false;
+  } else if (did === distinctId()) {
+    // Person props belong only to the *current* user; never tag a rollup for a
+    // previous login (distinct_id ≠ current) with the new user's email/name.
     const set = personSet();
     if (set) props.$set = set;
   }
@@ -224,6 +272,7 @@ export function capture(
     distinct_id: did,
     properties: props,
     timestamp: opts.timestamp ?? new Date().toISOString(),
+    uuid: uuidFromInsertId(insertId),
   };
   appendAnalyticsQueue(JSON.stringify(item));
 }
@@ -347,9 +396,10 @@ function emitRollup(did: string, group: UsageEntry[]): void {
     if (e.agent) agentCount += 1;
   }
   // Content-derived id hashed over the EXACT entries (each command's timestamp +
-  // path + agent flag). A re-emitted copy of the same batch hashes identically so
-  // PostHog dedupes it on ingest; genuinely different batches hash differently
-  // (distinct per-command timestamps), so this never collapses real activity.
+  // path + agent flag). A re-emitted copy of the same batch hashes identically
+  // (and so gets the same event uuid, which PostHog dedupes on); genuinely
+  // different batches hash differently (distinct per-command timestamps), so
+  // this never collapses real activity.
   const insertId = createHash('sha1')
     .update(`${did}|${group.map((e) => `${e.ts}:${e.command}:${e.agent ? 1 : 0}`).join('|')}`)
     .digest('hex');
@@ -364,7 +414,12 @@ function emitRollup(did: string, group: UsageEntry[]): void {
       window_end: new Date(group[group.length - 1].ts).toISOString(),
       $insert_id: insertId,
     },
-    { distinctId: did, timestamp: new Date(group[group.length - 1].ts).toISOString() },
+    {
+      distinctId: did,
+      timestamp: new Date(group[group.length - 1].ts).toISOString(),
+      // Rollups bill at the anonymous rate; the person already exists.
+      personProfile: false,
+    },
   );
   debugLog(`rollup — ${group.length} command(s) for ${did}`);
 }
@@ -381,42 +436,88 @@ function commandPath(command: Command): string {
 
 /**
  * Start sending every queued event (this run's + any left over from prior
- * runs) in the background. Called once in preAction so the requests overlap
- * the command's own work. Opting out drops the backlog instead of sending it.
+ * runs) in the background, so the requests overlap the command's own work.
+ * Called in preAction and again in postAction (for a rollup that came due
+ * during the command). Opting out drops the backlog instead of sending it.
+ *
+ * Bounded: an event is dispatched at most SEND_MAX_ATTEMPTS times in total
+ * (the count is persisted before the send so a crash can't reset it) and is
+ * dropped unsent once older than QUEUE_MAX_AGE_MS. A line an older CLI wrote
+ * without a `uuid` gets one here, so an inherited backlog dedupes too.
  */
 export function drainQueue(): void {
   if (isTelemetryDisabled()) {
     writeAnalyticsQueue([]);
     return;
   }
+  const now = Date.now();
+  const kept: string[] = [];
+  let changed = false;
   for (const line of readAnalyticsQueue()) {
+    let item: QueuedEvent;
     try {
-      const item = JSON.parse(line) as QueuedEvent;
-      if (item?.properties?.$insert_id) send(item);
+      item = JSON.parse(line) as QueuedEvent;
     } catch {
-      // Skip malformed lines; flush() prunes them from the queue.
+      changed = true; // drop a malformed line
+      continue;
     }
+    const insertId = item?.properties?.$insert_id as string | undefined;
+    if (!insertId) {
+      changed = true;
+      continue;
+    }
+    const age = now - Date.parse(item.timestamp);
+    const attempts = item.attempts ?? 0;
+    if (!(age < QUEUE_MAX_AGE_MS) || attempts >= SEND_MAX_ATTEMPTS) {
+      debugLog(`"${item.event}" dropped (${attempts} attempts, ${Math.round(age / 60_000)} min old)`);
+      changed = true;
+      continue;
+    }
+    if (dispatched.has(insertId)) {
+      kept.push(line); // already in flight (or delivered) this run; flush() settles it
+      continue;
+    }
+    item.attempts = attempts + 1;
+    if (!item.uuid) item.uuid = uuidFromInsertId(insertId);
+    kept.push(JSON.stringify(item));
+    changed = true;
+    send(item);
   }
+  if (changed) writeAnalyticsQueue(kept);
 }
 
 /**
- * Called from postAction. Abort any still-in-flight sends so a pending request
- * can't hold the process open (and the user waiting) on the network, then
- * rewrite the queue to keep only events NOT yet confirmed delivered — those
- * are retried on the next run.
+ * Called from postAction. Give in-flight sends a short grace period to land,
+ * abort whatever is still pending so it can't hold the process open (and the
+ * user waiting), then rewrite the queue to keep only events NOT yet confirmed
+ * delivered and still under the attempt cap — those are retried next run.
  */
-export function flush(): void {
+export async function flush(): Promise<void> {
+  if (pending.size > 0) {
+    // The timer is deliberately NOT unref'd: it is the only thing guaranteed
+    // to keep the process alive until the queue below is pruned, and it is
+    // bounded to EXIT_GRACE_MS.
+    await Promise.race([
+      Promise.allSettled([...pending]),
+      new Promise<void>((resolve) => setTimeout(resolve, EXIT_GRACE_MS)),
+    ]);
+  }
   for (const controller of inFlight) controller.abort();
 
   const remaining = readAnalyticsQueue().filter((line) => {
     try {
-      const id = (JSON.parse(line) as QueuedEvent).properties?.$insert_id as string | undefined;
-      return id ? !delivered.has(id) : false;
+      const item = JSON.parse(line) as QueuedEvent;
+      const id = item.properties?.$insert_id as string | undefined;
+      if (!id || delivered.has(id)) return false;
+      return (item.attempts ?? 0) < SEND_MAX_ATTEMPTS;
     } catch {
       return false; // drop malformed lines
     }
   });
   writeAnalyticsQueue(remaining);
+  // The run is over: the next drain (in this process, e.g. tests) starts clean.
+  dispatched.clear();
+  delivered.clear();
 }
 
 /**


### PR DESCRIPTION
## Summary

Part of the PostHog optimization plan (Cleanup → volume reduction). `CLI Usage Rollup` is 86% of all PostHog events (~1M/week), and 93% of that comes from **two users' Macs** — not from heavy usage, but from the CLI re-sending the same rollups over and over:

- PostHog dedupes on the event **`uuid`**, not on `$insert_id`, which the CLI relied on.
- A CLI process aborts in-flight sends at exit; the request body has usually already left, so PostHog ingests the event while the CLI keeps it queued for "retry next run". Every quick command then re-sends the whole backlog. One user's queue re-sent each rollup **~233 times** (45,215 events from 194 real rollups in 2 days).
- Side effect: the internal metrics dashboard multiplies `command_count` by those duplicates.

## Changes (`src/lib/analytics.ts`, `src/cli.ts`)

- **Idempotent retries.** Every queued event carries a `uuid` derived deterministically from its `$insert_id` (`uuidFromInsertId`, v5-shaped) and sends it in the POST body. Queue lines written by an older CLI get one when drained, so an inherited backlog dedupes on upgrade.
- **Bounded queue.** `drainQueue()` counts dispatches per event (persisted *before* the send so a crash can't reset it), drops an event after `SEND_MAX_ATTEMPTS = 3` or `QUEUE_MAX_AGE_MS = 24h`, and never dispatches the same event twice in one run.
- **Exit grace.** `flush()` (now async) waits up to `EXIT_GRACE_MS = 300` for in-flight sends only when there are any, then aborts the rest. `postAction` also drains the queue so a rollup emitted at exit usually lands in the same run instead of on the next one. Worst case added exit latency: 300 ms, only on runs that had something to send.
- **Anonymous-rate rollups.** Rollups carry `$process_person_profile: false` and no `$set` (sheet row: "rollups do not need person profiles"). Note: person-property filters (e.g. the project's internal-user filter by email) won't apply to rollup events; they still key on `distinct_id`.
- Version bump 1.55.2 → 1.55.3.

Expected effect once users update: CLI events drop from ~1M/week to roughly 70K/week.

## Test plan
- [x] `src/lib/analytics.test.ts`: 27 tests — the 17 existing rollup tests plus 10 new delivery tests using a stubbed `fetch` (uuid derivation + legacy backfill, uuid in the wire body, delivered events pruned, grace period lets a slow send land, attempts counted and capped, age cap, no double dispatch per run, failed send retried).
- [x] `npm run typecheck` clean; `npm run build` (tsup) succeeds.
- [x] Full suite: 468 pass; the 6 `resolveConfig` failures in `src/lib/config.test.ts` fail identically on a clean `main` (verified by stashing this change) and are unrelated.
- [ ] After release: `CLI Usage Rollup` volume per user in PostHog (HogQL `count() / uniq($insert_id)` per distinct_id) drops to ~1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)