### PR TITLE
fix(actions): unknown platform search is an error, not an empty result (v1.55.5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ one list
 
 # Search for actions you can take
 one actions search gmail "send email" -t execute
+# A misspelled platform exits 1 (not an empty result list).
+# `one --agent actions search bogus "test"` → {"error":"Unknown platform \"bogus\"",...}
 
 # Read the docs for an action
 one actions knowledge gmail <actionId>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@withone/cli",
-  "version": "1.55.4",
+  "version": "1.55.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withone/cli",
-      "version": "1.55.4",
+      "version": "1.55.5",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
         "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withone/cli",
-  "version": "1.55.4",
+  "version": "1.55.5",
   "description": "CLI for managing One",
   "type": "module",
   "files": [

--- a/skills/one/SKILL.md
+++ b/skills/one/SKILL.md
@@ -78,6 +78,7 @@ one --agent actions search <platform> "<query>" -t execute
 - Platform names are lowercase; multi-word names use dashes: `gmail`, `hubspot`, `ship-station`, `google-calendar`
 - Use `-t execute` when performing actions, `-t knowledge` when researching or writing code
 - If no results, broaden the query (e.g., `"list"` instead of `"list active premium customers"`)
+- A misspelled platform is **not** an empty result: the command exits 1 with `{"error":"Unknown platform \"...\"","similar":[...]}`. Exit 0 with `{"actions":[]}` means the platform exists and the query matched nothing. Check the `error` key before treating empty `actions` as "no matches".
 
 ### 3. Get the action's knowledge (REQUIRED before executing)
 

--- a/src/commands/actions.search-unknown.test.ts
+++ b/src/commands/actions.search-unknown.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { actionsSearchCommand } from './actions.js';
+import { searchCachePath } from '../lib/cache.js';
+import { setHomeTo, snapshotHomeEnv, restoreHomeEnv, type HomeEnvSnapshot } from '../test-support/home.js';
+
+interface Harness {
+  server: http.Server;
+  port: number;
+  counts: { search: number; connectors: number };
+}
+
+function startServer(opts: { platforms: string[]; searchHits: boolean }): Promise<Harness> {
+  const counts = { search: 0, connectors: 0 };
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url ?? '/', 'http://localhost');
+    if (url.pathname.startsWith('/v1/available-actions/search/')) {
+      counts.search++;
+      res.setHeader('content-type', 'application/json');
+      if (opts.searchHits) {
+        res.end(JSON.stringify([{
+          systemId: 'gmail::send',
+          title: 'Send email',
+          method: 'POST',
+          path: '/gmail/v1/users/{userId}/messages/send',
+        }]));
+      } else {
+        res.end('[]');
+      }
+      return;
+    }
+    if (url.pathname === '/v1/available-connectors') {
+      counts.connectors++;
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify({
+        rows: opts.platforms.map((p, i) => ({
+          id: i + 1,
+          name: p === 'gmail' ? 'Gmail' : p,
+          key: p,
+          platform: p,
+          category: 'Other',
+        })),
+        total: opts.platforms.length,
+        pages: 1,
+        page: 1,
+      }));
+      return;
+    }
+    res.statusCode = 404;
+    res.end('{}');
+  });
+  return new Promise((resolve) => {
+    server.listen(0, () => {
+      const port = (server.address() as AddressInfo).port;
+      resolve({ server, port, counts });
+    });
+  });
+}
+
+describe('actions search unknown platform (agent mode)', () => {
+  let tmpHome: string;
+  let originalHome: HomeEnvSnapshot;
+  let originalAgent: string | undefined;
+  let originalWrite: typeof process.stdout.write;
+  let originalExit: typeof process.exit;
+  let lines: string[];
+  let exitCode: number | undefined;
+  let harness: Harness;
+
+  beforeEach(() => {
+    originalHome = snapshotHomeEnv();
+    originalAgent = process.env.ONE_AGENT;
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'one-cli-search-unknown-'));
+    setHomeTo(tmpHome);
+    process.env.ONE_AGENT = '1';
+
+    lines = [];
+    originalWrite = process.stdout.write.bind(process.stdout);
+    process.stdout.write = ((chunk: any, ...rest: any[]) => {
+      const s = typeof chunk === 'string' ? chunk : String(chunk);
+      if (s.trim().startsWith('{')) { lines.push(s); return true; }
+      return (originalWrite as any)(chunk, ...rest);
+    }) as typeof process.stdout.write;
+
+    exitCode = undefined;
+    originalExit = process.exit;
+    process.exit = ((code?: number) => {
+      exitCode = code ?? 0;
+      throw new Error(`process.exit(${exitCode})`);
+    }) as typeof process.exit;
+  });
+
+  afterEach(() => {
+    process.stdout.write = originalWrite;
+    process.exit = originalExit;
+    restoreHomeEnv(originalHome);
+    if (originalAgent === undefined) delete process.env.ONE_AGENT; else process.env.ONE_AGENT = originalAgent;
+    harness?.server.close();
+    fs.rmSync(tmpHome, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
+  });
+
+  function lastJson(): any {
+    const jsonLines = lines.filter((l) => l.trim().startsWith('{'));
+    return JSON.parse(jsonLines[jsonLines.length - 1]);
+  }
+
+  function writeConfig(port: number) {
+    fs.mkdirSync(path.join(tmpHome, '.one'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpHome, '.one', 'config.json'),
+      JSON.stringify({ apiKey: 'sk_test', apiBase: `http://localhost:${port}` })
+    );
+  }
+
+  it('exits 1 with error+similar and does not cache a misspelled platform', async () => {
+    harness = await startServer({ platforms: ['gmail'], searchHits: false });
+    writeConfig(harness.port);
+
+    await assert.rejects(
+      () => actionsSearchCommand('bogus-platform-xyz', 'test', { type: 'execute' }),
+      /process\.exit\(1\)/
+    );
+
+    const out = lastJson();
+    assert.equal(out.error, 'Unknown platform "bogus-platform-xyz"');
+    assert.ok(Array.isArray(out.similar));
+    assert.equal(exitCode, 1);
+    assert.equal(harness.counts.connectors, 1);
+
+    const cachePath = searchCachePath('bogus-platform-xyz', 'test', 'execute');
+    assert.equal(fs.existsSync(cachePath), false);
+  });
+
+  it('exit 0 with empty actions when the platform exists and the query matches nothing', async () => {
+    harness = await startServer({ platforms: ['gmail'], searchHits: false });
+    writeConfig(harness.port);
+
+    await actionsSearchCommand('gmail', 'zzzz-no-such-action', { type: 'execute' });
+
+    const out = lastJson();
+    assert.equal(out.error, undefined);
+    assert.deepEqual(out.actions, []);
+    assert.equal(exitCode, undefined);
+  });
+
+  it('does not consult the catalog when search returns hits', async () => {
+    harness = await startServer({ platforms: ['gmail'], searchHits: true });
+    writeConfig(harness.port);
+
+    await actionsSearchCommand('gmail', 'send email', { type: 'execute' });
+
+    const out = lastJson();
+    assert.equal(out.actions.length, 1);
+    assert.equal(out.actions[0].actionId, 'gmail::send');
+    assert.equal(harness.counts.connectors, 0);
+    assert.equal(exitCode, undefined);
+  });
+});

--- a/src/commands/actions.ts
+++ b/src/commands/actions.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import * as p from '@clack/prompts';
 import pc from 'picocolors';
 import { getApiKey, getApiBase, getAccessControlFromAllSources } from '../lib/config.js';
@@ -8,9 +9,10 @@ import {
   isMethodAllowed,
   buildActionKnowledgeWithGuidance,
 } from '../lib/api.js';
+import { findPlatform, findSimilarPlatforms } from '../lib/platforms.js';
 import { printTable } from '../lib/table.js';
 import * as output from '../lib/output.js';
-import type { PermissionLevel, ActionKnowledgeResponse, ActionDetails, SearchCacheData, SearchCacheAction } from '../lib/types.js';
+import type { PermissionLevel, ActionKnowledgeResponse, ActionDetails, SearchCacheData, SearchCacheAction, CacheEntry } from '../lib/types.js';
 import { validateActionInput } from '../lib/validate.js';
 import { resolveActionDetails } from '../lib/action-details.js';
 import {
@@ -48,6 +50,53 @@ function parseJsonArg(value: string, argName: string): any {
   }
 }
 
+class UnknownPlatformError extends Error {
+  readonly similar: string[];
+  readonly hint: string;
+  constructor(platform: string, similar: string[], hint: string) {
+    super(`Unknown platform "${platform}"`);
+    this.name = 'UnknownPlatformError';
+    this.similar = similar;
+    this.hint = hint;
+  }
+}
+
+/**
+ * Empty search results on a misspelled platform used to look identical to a
+ * real platform with no matches (exit 0, `{actions:[]}`, and the miss was
+ * cached). Throws UnknownPlatformError so the caller can exit 1 with a
+ * structured body and drop any cache file.
+ *
+ * Catalog fetch failure is swallowed so a downed `/available-connectors`
+ * cannot turn a genuine empty search into a crash.
+ */
+async function rejectIfUnknownPlatform(
+  api: OneApi,
+  platform: string,
+  cachePath: string,
+): Promise<void> {
+  let platforms;
+  try {
+    platforms = await api.listPlatforms();
+  } catch {
+    return;
+  }
+  if (findPlatform(platforms, platform)) return;
+
+  try {
+    fs.unlinkSync(cachePath);
+  } catch {
+    // no cache file — fine
+  }
+
+  const similar = findSimilarPlatforms(platforms, platform).map((p) => p.platform);
+  throw new UnknownPlatformError(
+    platform,
+    similar,
+    'Run `one --agent platforms` (or `one platforms`) to list platforms.',
+  );
+}
+
 export async function actionsSearchCommand(
   platform: string,
   query: string,
@@ -74,6 +123,7 @@ export async function actionsSearchCommand(
 
     let cleanedActions: SearchCacheAction[];
     let cacheHit = false;
+    let pendingCache: CacheEntry<SearchCacheData> | null = null;
 
     if (cached && isFresh(cached)) {
       // Serve from cache
@@ -104,13 +154,12 @@ export async function actionsSearchCommand(
             path: action.path,
           }));
 
-          // Write to cache, recording the request params so `cache update`
-          // can re-run this exact search later.
-          writeCache(cachePath, makeCacheEntry(
+          // Defer the write until we know this isn't a misspelled platform.
+          pendingCache = makeCacheEntry(
             `${platform}_${query}_${searchType}`,
             { actions: cleanedActions, platform, query, searchType },
             result.etag
-          ));
+          );
         }
       } catch (fetchError) {
         // Network failure — serve stale cache if available
@@ -124,6 +173,14 @@ export async function actionsSearchCommand(
           throw fetchError;
         }
       }
+    }
+
+    if (cleanedActions.length === 0) {
+      await rejectIfUnknownPlatform(api, platform, cachePath);
+    }
+
+    if (pendingCache) {
+      writeCache(cachePath, pendingCache);
     }
 
     if (output.isAgentMode()) {
@@ -186,6 +243,21 @@ export async function actionsSearchCommand(
       'Next Steps'
     );
   } catch (error) {
+    if (error instanceof UnknownPlatformError) {
+      spinner.stop('Unknown platform');
+      if (output.isAgentMode()) {
+        output.json({
+          error: error.message,
+          similar: error.similar,
+          hint: error.hint,
+        });
+        process.exit(1);
+      }
+      const suggestion = error.similar.length
+        ? `\nDid you mean: ${error.similar.join(', ')}`
+        : '';
+      output.error(`${error.message}.${suggestion}\n\n${error.hint}`);
+    }
     spinner.stop('Search failed');
     output.error(
       `Error: ${error instanceof Error ? error.message : 'Unknown error'}`

--- a/src/lib/guide-content.ts
+++ b/src/lib/guide-content.ts
@@ -240,11 +240,19 @@ The CLI validates required parameters before executing. Missing params return a 
 
 All errors return JSON: \`{"error": "message"}\`. Check the \`error\` key.
 
+A misspelled platform on \`actions search\` is **not** an empty result. The command exits 1 with:
+
+\`\`\`json
+{"error": "Unknown platform \\"bogus-platform-xyz\\"", "similar": ["gmail"], "hint": "Run \`one --agent platforms\` (or \`one platforms\`) to list platforms."}
+\`\`\`
+
+Exit 0 with \`{"actions": []}\` means the platform exists and the query matched nothing — broaden the query. Unknown-platform misses are not cached.
+
 ## Notes
 
 - Platform names are **lowercase**; multi-word names use dashes (e.g., \`hubspot\`, \`ship-station\`)
 - JSON flags use single quotes around the JSON to avoid shell escaping
-- If search returns no results, try broader queries
+- If search returns no results, try broader queries — but first confirm the platform slug is real
 - Access control settings from \`one config\` may restrict execution
 `;
 

--- a/src/lib/platforms.test.ts
+++ b/src/lib/platforms.test.ts
@@ -1,0 +1,41 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { findPlatform, findSimilarPlatforms } from './platforms.js';
+import type { Platform } from './types.js';
+
+function plat(slug: string, name = slug): Platform {
+  return {
+    id: 1,
+    name,
+    key: slug,
+    platform: slug,
+    category: 'Other',
+  };
+}
+
+describe('findPlatform', () => {
+  const catalog = [plat('gmail', 'Gmail'), plat('google-calendar', 'Google Calendar')];
+
+  it('matches slug case-insensitively', () => {
+    assert.equal(findPlatform(catalog, 'Gmail')?.platform, 'gmail');
+    assert.equal(findPlatform(catalog, 'gmail')?.platform, 'gmail');
+  });
+
+  it('matches display name', () => {
+    assert.equal(findPlatform(catalog, 'Google Calendar')?.platform, 'google-calendar');
+  });
+
+  it('returns null for a misspelling', () => {
+    assert.equal(findPlatform(catalog, 'bogus-platform-xyz'), null);
+  });
+});
+
+describe('findSimilarPlatforms', () => {
+  const catalog = [plat('gmail', 'Gmail'), plat('google-calendar', 'Google Calendar'), plat('slack', 'Slack')];
+
+  it('ranks a close slug above unrelated ones', () => {
+    const similar = findSimilarPlatforms(catalog, 'gmai');
+    assert.ok(similar.length > 0);
+    assert.equal(similar[0].platform, 'gmail');
+  });
+});


### PR DESCRIPTION
## Summary

`one --agent actions search bogus-platform-xyz "test"` returned `{actions:[]}` with exit 0 and **cached** the miss. A typo was indistinguishable from a real platform with no matching actions, which breaks any flow that chains on search results.

On an empty search result, the CLI now looks the slug up in `/available-connectors`:

- **Unknown platform** → exit 1, `{error, similar, hint}`, cache entry discarded
- **Known platform, no matches** → unchanged (`{actions:[]}`, exit 0)

Catalog lookup is skipped when search already returned hits, so the happy path does not pay an extra request. If the catalog itself is unreachable, we fall through to the existing empty-result path rather than failing a genuine miss.

## Test plan

- [x] `actions search unknown platform (agent mode)` — typo exits 1, no cache file, known-empty stays exit 0, hits skip the catalog
- [x] `findPlatform` / `findSimilarPlatforms` unit tests
- [x] `execute _preflight` still passes
- [x] `tsc --noEmit`

```bash
one --agent actions search bogus-platform-xyz "test"
# → {"error":"Unknown platform \"bogus-platform-xyz\"","similar":[...],"hint":"..."}  exit 1

one --agent actions search gmail "zzzz-no-such-action"
# → {"actions":[],"_cache":{...}}  exit 0
```